### PR TITLE
Implement ELO progression, better progress tracking and archive flow

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,6 +1,7 @@
 output-path: ./lcov.info
 ignore:
   - "src/main.rs"
+  - "src/model/*.rs"
   - "../*"
   - "/*"
 ignore-not-existing: true

--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,6 +1,7 @@
 output-path: ./lcov.info
 ignore:
   - "src/main.rs"
+  - "src/dir.rs"
   - "src/model/*.rs"
   - "../*"
   - "/*"

--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -2,6 +2,7 @@ output-path: ./lcov.info
 ignore:
   - "src/main.rs"
   - "src/dir.rs"
+  - "src/train.rs"
   - "src/model/*.rs"
   - "../*"
   - "/*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,12 +296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,7 +367,6 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs",
- "fs_extra",
  "num_cpus",
  "rand 0.6.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ chess = "3.2.0"
 crossterm = "0.19.0"
 ctrlc = "3.1.9"
 dirs = "3.0.1"
-fs_extra = "1.2.0"
 num_cpus = "1.13.0"
 rand = "0.6.5"
 serde = { version = "1.0.125", features = ["derive"] }

--- a/scripts/evolution_display.py
+++ b/scripts/evolution_display.py
@@ -1,0 +1,94 @@
+# Displays live updates on network statistics.
+
+import appdirs
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+import time
+from os import path
+import sys
+
+# Locate archive directory
+archive_dir = path.join(appdirs.user_data_dir(roaming=True), 'kami', 'archive')
+
+if not path.exists(archive_dir):
+    print('Archive directory "{}" not found'.format(archive_dir))
+    sys.exit(-1)
+
+# Yields available generation paths in order.
+def generations():
+    current_gen = 0
+
+    while True:
+        nextpath = path.join(archive_dir, 'generation_{}'.format(current_gen))
+
+        if not path.exists(nextpath):
+            break
+
+        yield nextpath
+        current_gen += 1
+
+# Yields games in JSON format from a generation in order.
+def games(gen):
+    current_game = 0
+
+    while True:
+        nextpath = path.join(gen, 'games', '{}.game'.format(current_game))
+
+        if not path.exists(nextpath):
+            break
+
+        with open(nextpath) as f:
+            yield json.load(f)
+
+        current_game += 1
+
+# Walks through generations and returns data for display.
+# Returns (mean game ply / generation), (total ply / generation)
+def generate_datasets():
+    print('Computing average ply .. ', end='')
+    data_mean = []
+    data_total = []
+
+    for genpath in generations():
+        total = 0
+        n = 0
+
+        for game in games(genpath):
+            total += len(game['actions'])
+            n += 1
+
+        data_mean.append(total / n)
+        data_total.append(total)
+    print('done')
+    return data_mean, data_total
+
+# Collects data and renders it on the screen.
+def render_plots():
+    fig, (ply_total, ply_mean) = plt.subplots(2, 1)
+    fig.suptitle('Kami model evolution statistics')
+
+    # Render average game ply
+    ply_mean_y, ply_total_y = generate_datasets()
+    ply_x = list(range(len(ply_mean_y)))
+
+    ply_mean.plot(ply_x, ply_mean_y, '.-')
+    ply_mean.set_xlabel('Generation #')
+    ply_mean.set_ylabel('Average game ply')
+    ply_mean.set(ylim=(0, 400))
+    ply_mean.grid()
+
+    ply_total.plot(ply_x, ply_total_y, '.-')
+    ply_total.set(ylim=(0, 2500))
+    ply_total.set_xlabel('Generation #')
+    ply_total.set_ylabel('Total training set ply')
+    ply_total.grid()
+
+    plt.show()
+
+UPDATE_INTERVAL = 60 # display update interval, in seconds
+
+# Start rendering data.
+while True:
+    render_plots()
+    time.sleep(UPDATE_INTERVAL)

--- a/scripts/evolution_display.py
+++ b/scripts/evolution_display.py
@@ -44,13 +44,13 @@ def games(gen):
         current_game += 1
 
 # Walks through generations and returns data for display.
-# Returns (mean game ply / generation), (total ply / generation)
+# Returns (mean game ply / generation), elo_y, elo_x
 def generate_datasets():
-    print('Computing average ply .. ', end='')
     data_mean = []
-    data_total = []
+    elo_x = []
+    elo_y = []
 
-    for genpath in generations():
+    for gen, genpath in enumerate(generations()):
         total = 0
         n = 0
 
@@ -58,18 +58,24 @@ def generate_datasets():
             total += len(game['actions'])
             n += 1
 
+        elo_path = path.join(genpath, 'games', 'elo')
+        if path.exists(elo_path):
+            elo_x.append(gen)
+
+            with open(elo_path) as f:
+                elo_y.append(int(f.read()))
+
         data_mean.append(total / n)
-        data_total.append(total)
-    print('done')
-    return data_mean, data_total
+
+    return data_mean, elo_x, elo_y
 
 # Collects data and renders it on the screen.
 def render_plots():
-    fig, (ply_total, ply_mean) = plt.subplots(2, 1)
+    fig, (elo, ply_mean) = plt.subplots(2, 1)
     fig.suptitle('Kami model evolution statistics')
 
     # Render average game ply
-    ply_mean_y, ply_total_y = generate_datasets()
+    ply_mean_y, elo_x, elo_y = generate_datasets()
     ply_x = list(range(len(ply_mean_y)))
 
     ply_mean.plot(ply_x, ply_mean_y, '.-')
@@ -78,11 +84,11 @@ def render_plots():
     ply_mean.set(ylim=(0, 400))
     ply_mean.grid()
 
-    ply_total.plot(ply_x, ply_total_y, '.-')
-    ply_total.set(ylim=(0, 2500))
-    ply_total.set_xlabel('Generation #')
-    ply_total.set_ylabel('Total training set ply')
-    ply_total.grid()
+    elo.plot(elo_x, elo_y, '.-')
+    elo.set_xlabel('Generation #')
+    elo.set_ylabel('Estimated ELO rating')
+    elo.set(ylim=(0, 2500), xlim=(0, len(ply_mean_y)))
+    elo.grid()
 
     plt.show()
 

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -115,6 +115,11 @@ for i in range(EPOCHS):
 print('Finished model training!')
 print('Final average loss: {} ---> {}'.format(first_avg_loss, last_avg_loss))
 
+# Write initial and ending average loss
+with open(sys.argv[3], 'w') as f:
+    f.write(str(first_avg_loss) + '\n')
+    f.write(str(last_avg_loss) + '\n')
+
 # Write trained model back to source.
 module.save(sys.argv[1])
 print('Saved model to {}'.format(sys.argv[1]))

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-LEARNING_RATE=0.0005
+LEARNING_RATE=1e-5
 FRAME_COUNT=6
 FRAME_SIZE=14
 HEADER_SIZE=18
@@ -53,7 +53,7 @@ def loss(policy, value, mcts, result):
 
 # Train model!
 
-optimizer = torch.optim.Adadelta(module.parameters())
+optimizer = torch.optim.RMSprop(module.parameters(), lr=LEARNING_RATE, weight_decay=0.01)
 first_avg_loss = None
 last_avg_loss = None
 
@@ -68,11 +68,7 @@ def train_loop():
 
         policy, value = module(headers, frames, lmm)
 
-        #l2_reg = 0
-        #for p in module.parameters():
-        #    l2_reg += 0.5 * (p ** 2).sum()
-
-        current_loss = loss(policy, value, mcts, result) # + l2_reg * L2_REG_WEIGHT
+        current_loss = loss(policy, value, mcts, result)
 
         #print("BEGIN")
         #print("policy: {}", policy)

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -53,7 +53,7 @@ def loss(policy, value, mcts, result):
 
 # Train model!
 
-optimizer = torch.optim.SGD(module.parameters(), lr = LEARNING_RATE)
+optimizer = torch.optim.Adadelta(module.parameters())
 first_avg_loss = None
 last_avg_loss = None
 
@@ -68,11 +68,11 @@ def train_loop():
 
         policy, value = module(headers, frames, lmm)
 
-        l2_reg = 0
-        for p in module.parameters():
-            l2_reg += 0.5 * (p ** 2).sum()
+        #l2_reg = 0
+        #for p in module.parameters():
+        #    l2_reg += 0.5 * (p ** 2).sum()
 
-        current_loss = loss(policy, value, mcts, result) + l2_reg * L2_REG_WEIGHT
+        current_loss = loss(policy, value, mcts, result) # + l2_reg * L2_REG_WEIGHT
 
         #print("BEGIN")
         #print("policy: {}", policy)

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-LEARNING_RATE=0.001
+LEARNING_RATE=0.0005
 FRAME_COUNT=6
 FRAME_SIZE=14
 HEADER_SIZE=18

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -14,6 +14,7 @@ FRAME_SIZE=14
 HEADER_SIZE=18
 EPOCHS = 10
 POLICY_EPSILON=1e-6
+L2_REG_WEIGHT = 1e-4
 DROPOUT = 0.3
 
 # Load module from path
@@ -71,7 +72,7 @@ def train_loop():
         for p in module.parameters():
             l2_reg += 0.5 * (p ** 2).sum()
 
-        current_loss = loss(policy, value, mcts, result)
+        current_loss = loss(policy, value, mcts, result) + l2_reg * L2_REG_WEIGHT
 
         #print("BEGIN")
         #print("policy: {}", policy)

--- a/scripts/train_torch.py
+++ b/scripts/train_torch.py
@@ -117,8 +117,7 @@ print('Final average loss: {} ---> {}'.format(first_avg_loss, last_avg_loss))
 
 # Write initial and ending average loss
 with open(sys.argv[3], 'w') as f:
-    f.write(str(first_avg_loss) + '\n')
-    f.write(str(last_avg_loss) + '\n')
+    f.write('{} {}\n'.format(first_avg_loss, last_avg_loss))
 
 # Write trained model back to source.
 module.save(sys.argv[1])

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,9 +12,11 @@ pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
 pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
 pub const ELO_EVALUATION_NUM_GAMES: usize = 6;
-pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] =
+pub const STOCKFISH_ELO: [i32; ELO_EVALUATION_NUM_GAMES] =
     [200, 600, 1000, 1400, 1800, 2200]; // stockfish elo settings for ELO evaluation
 pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
+pub const ELO_EVALUATION_INITIAL: i32 = 0; // Initial ELO to assume in evaluation
+pub const ELO_EVALUATION_K: f32 = 75.0; // ELO k factor, keep high for more fluid estimates
 pub const PUCT_POLICY_WEIGHT: f64 = 4.0; // Weight of policy in PUCT calculation
 pub const PUCT_NOISE_ALPHA: f64 = 0.285; // Dirichlet noise parameter to add to P before PUCT calculation
 pub const PUCT_NOISE_WEIGHT: f64 = 0.25; // Weight of noise vs. network policy

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,12 +3,12 @@ use crate::model;
 
 pub const TRAINING_SET_SIZE: usize = 4; // number of games played per generation
 pub const SEARCH_TIME: usize = 10000; // milliseconds per move (if node target not reached)
-pub const SEARCH_MAXNODES: usize = 8000; // maximum nodes searched per move
+pub const SEARCH_MAXNODES: usize = 4000; // maximum nodes searched per move
 pub const SEARCH_STATUS_RATE: u64 = 100; // milliseconds between search status reports
 pub const TEMPERATURE: f64 = 1.0; // MCTS initial temperature
 pub const SEARCH_BATCH_SIZE: usize = 16; // number of nodes to expand at once on a single thread
-pub const TRAINING_BATCH_SIZE: usize = 32; // numb of decisions in each training batch
-pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
+pub const TRAINING_BATCH_SIZE: usize = 16; // numb of decisions in each training batch
+pub const TRAINING_BATCH_COUNT: usize = 16; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
 pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
 pub const ELO_EVALUATION_NUM_GAMES: usize = 6;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,10 @@
-/// Several configuration constants for the search.
+/// Several configuration constants.
 
-pub const TRAINING_SET_SIZE: usize = 8; // number of games played per generation
+use crate::model;
+
+pub const TRAINING_SET_SIZE: usize = 4; // number of games played per generation
 pub const SEARCH_TIME: usize = 10000; // milliseconds per move (if node target not reached)
-pub const SEARCH_MAXNODES: usize = 12000; // maximum nodes searched per move
+pub const SEARCH_MAXNODES: usize = 8000; // maximum nodes searched per move
 pub const SEARCH_STATUS_RATE: u64 = 100; // milliseconds between search status reports
 pub const TEMPERATURE: f64 = 1.0; // MCTS initial temperature
 pub const TEMPERATURE_DROPOFF: f64 = 0.1; // MCTS final temperature
@@ -11,3 +13,11 @@ pub const SEARCH_BATCH_SIZE: usize = 16; // number of nodes to expand at once on
 pub const TRAINING_BATCH_SIZE: usize = 32; // number of decisions in each training batch
 pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
+pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
+pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
+
+#[cfg(feature = "tch")]
+pub const DEFAULT_MODEL_TYPE: model::Type = model::Type::Torch; // model type to initialize
+
+#[cfg(not(feature = "tch"))]
+pub const DEFAULT_MODEL_TYPE: model::Type = model::Type::Torch; // model type to initialize

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,9 +11,9 @@ pub const TRAINING_BATCH_SIZE: usize = 32; // numb of decisions in each training
 pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
 pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
-pub const ELO_EVALUATION_NUM_GAMES: usize = 10;
+pub const ELO_EVALUATION_NUM_GAMES: usize = 6;
 pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] =
-    [200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000]; // stockfish elo settings for ELO evaluation
+    [200, 600, 1000, 1400, 1800, 2200]; // stockfish elo settings for ELO evaluation
 pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
 pub const PUCT_POLICY_WEIGHT: f64 = 4.0; // Weight of policy in PUCT calculation
 pub const PUCT_NOISE_ALPHA: f64 = 0.285; // Dirichlet noise parameter to add to P before PUCT calculation

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,6 +14,8 @@ pub const TRAINING_BATCH_SIZE: usize = 32; // number of decisions in each traini
 pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
 pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
+pub const ELO_EVALUATION_NUM_GAMES: usize = 10;
+pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] = [200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000]; // stockfish elo settings for ELO evaluation
 pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
 
 #[cfg(feature = "tch")]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,6 +17,9 @@ pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
 pub const ELO_EVALUATION_NUM_GAMES: usize = 10;
 pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] = [200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000]; // stockfish elo settings for ELO evaluation
 pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
+pub const PUCT_POLICY_WEIGHT: f64 = 4.0; // Weight of policy in PUCT calculation
+pub const PUCT_NOISE_ALPHA: f64 = 0.285; // Dirichlet noise parameter to add to P before PUCT calculation
+pub const PUCT_NOISE_WEIGHT: f64 = 0.25; // Weight of noise vs. network policy
 
 #[cfg(feature = "tch")]
 pub const DEFAULT_MODEL_TYPE: model::Type = model::Type::Torch; // model type to initialize

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,4 @@
 /// Several configuration constants.
-
 use crate::model;
 
 pub const TRAINING_SET_SIZE: usize = 4; // number of games played per generation
@@ -7,15 +6,14 @@ pub const SEARCH_TIME: usize = 10000; // milliseconds per move (if node target n
 pub const SEARCH_MAXNODES: usize = 8000; // maximum nodes searched per move
 pub const SEARCH_STATUS_RATE: u64 = 100; // milliseconds between search status reports
 pub const TEMPERATURE: f64 = 1.0; // MCTS initial temperature
-pub const TEMPERATURE_DROPOFF: f64 = 0.1; // MCTS final temperature
-pub const TEMPERATURE_DROPOFF_PLY: usize = 1000; // ply to switch from initial to dropoff temperature
 pub const SEARCH_BATCH_SIZE: usize = 16; // number of nodes to expand at once on a single thread
-pub const TRAINING_BATCH_SIZE: usize = 32; // number of decisions in each training batch
+pub const TRAINING_BATCH_SIZE: usize = 32; // numb of decisions in each training batch
 pub const TRAINING_BATCH_COUNT: usize = 32; // number of training batches
 pub const TUI_FRAME_RATE: u64 = 15; // TUI framerate (frames/second)
 pub const MOVETIME_ELO: usize = 2000; // MS per move during ELO evaluation
 pub const ELO_EVALUATION_NUM_GAMES: usize = 10;
-pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] = [200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000]; // stockfish elo settings for ELO evaluation
+pub const STOCKFISH_ELO: [usize; ELO_EVALUATION_NUM_GAMES] =
+    [200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000]; // stockfish elo settings for ELO evaluation
 pub const ELO_EVALUATION_INTERVAL: usize = 25; // Perform ELO evaluation every n generations
 pub const PUCT_POLICY_WEIGHT: f64 = 4.0; // Weight of policy in PUCT calculation
 pub const PUCT_NOISE_ALPHA: f64 = 0.285; // Dirichlet noise parameter to add to P before PUCT calculation

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,7 +2,6 @@
 use crate::model;
 
 pub const TRAINING_SET_SIZE: usize = 4; // number of games played per generation
-pub const SEARCH_TIME: usize = 10000; // milliseconds per move (if node target not reached)
 pub const SEARCH_MAXNODES: usize = 4000; // maximum nodes searched per move
 pub const SEARCH_STATUS_RATE: u64 = 100; // milliseconds between search status reports
 pub const TEMPERATURE: f64 = 1.0; // MCTS initial temperature

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,5 +1,4 @@
 /// Methods for manipulating kami paths and directories.
-
 use crate::constants;
 use crate::game::Game;
 
@@ -34,10 +33,14 @@ pub fn model_dir() -> Result<PathBuf, Box<dyn Error>> {
 
     if out.exists() {
         if !out.is_dir() {
-            return Err(format!("Model path {} exists but is not a directory!", out.display()).into());
+            return Err(format!(
+                "Model path {} exists but is not a directory!",
+                out.display()
+            )
+            .into());
         }
     }
-    
+
     return Ok(out);
 }
 
@@ -63,7 +66,11 @@ pub fn current_generation() -> Result<usize, Box<dyn Error>> {
                 continue;
             }
 
-            return Err(format!("Generation path {} exists but is not a directory!", genpath.display()).into());
+            return Err(format!(
+                "Generation path {} exists but is not a directory!",
+                genpath.display()
+            )
+            .into());
         } else {
             break;
         }
@@ -102,7 +109,7 @@ pub fn next_game() -> Result<Option<PathBuf>, Box<dyn Error>> {
 
             continue;
         }
-        
+
         return Ok(Some(gpath));
     }
 
@@ -127,7 +134,7 @@ pub fn next_elo_game() -> Result<Option<(PathBuf, usize)>, Box<dyn Error>> {
 
             continue;
         }
-        
+
         return Ok(Some((gpath, i)));
     }
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -3,7 +3,6 @@ use crate::constants;
 use crate::game::Game;
 
 use dirs;
-use fs_extra;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,0 +1,118 @@
+/// Methods for manipulating kami paths and directories.
+
+use crate::constants;
+use crate::game;
+
+use dirs;
+use fs_extra;
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+/// Returns the path to the root data directory.
+pub fn data_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let out = match dirs::data_dir() {
+        Some(dd) => dd.join("kami"),
+        None => return Err("No data directory available!".into()),
+    };
+
+    fs::create_dir_all(&out)?;
+    Ok(out)
+}
+
+/// Returns the path to the archive directory.
+pub fn archive_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let out = data_dir()?.join("archive");
+    fs::create_dir_all(&out)?;
+
+    Ok(out)
+}
+
+/// Returns the path to the current model.
+pub fn model_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let out = data_dir()?.join("model");
+
+    if out.exists() {
+        if !out.is_dir() {
+            return Err(format!("Model path {} exists but is not a directory!", out.display()).into());
+        }
+    }
+    
+    return Ok(out);
+}
+
+/// Returns the path to the games directory.
+pub fn games_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let out = data_dir()?.join("games");
+    fs::create_dir_all(&out)?;
+
+    Ok(out)
+}
+
+/// Returns the path to the ELO evaluation directory. Panics if the directory cannot be located or initialized.
+pub fn elo_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let out = data_dir()?.join("elo");
+    fs::create_dir_all(&out)?;
+
+    Ok(out)
+}
+
+/// Returns the current model generation number. Panics if an error occurs, or returns 0 if no models are archived.
+pub fn current_generation() -> Result<usize, Box<dyn Error>> {
+    let mut current = 0;
+    let archive_path = archive_dir()?;
+
+    loop {
+        let genpath = archive_path.join(format!("generation_{}", current));
+
+        if genpath.exists() {
+            if genpath.is_dir() {
+                current += 1;
+                continue;
+            }
+
+            return Err(format!("Generation path {} exists but is not a directory!", genpath.display()).into());
+        } else {
+            break;
+        }
+    }
+
+    return Ok(current);
+}
+
+/// Archives the current model and games. Returns the archived generation number.
+pub fn archive() -> Result<usize, Box<dyn Error>> {
+    let current = current_generation()?;
+
+    let dest = archive_dir()?.join(format!("generation_{}", current));
+    fs::create_dir_all(&dest)?;
+
+    fs_extra::move_items(&[&games_dir()?], dest, &fs_extra::dir::CopyOptions::new())?;
+
+    Ok(current)
+}
+
+/// Gets the path for the next game to be generated (or resumed), otherwise returns None
+pub fn next_game() -> Result<Option<PathBuf>, Box<dyn Error>> {
+    let gdir = games_dir()?;
+
+    for i in 0..constants::TRAINING_SET_SIZE {
+        let gpath = gdir.join(format!("{}.game", i));
+
+        if gpath.exists() {
+            if !gpath.is_file() {
+                return Err(format!("Game {} exists but is not a file!", gpath.display()).into());
+            }
+
+            if !game::Game::load(&gpath)?.is_complete() {
+                return Ok(Some(gpath));
+            }
+
+            continue;
+        }
+        
+        return Ok(Some(gpath));
+    }
+
+    return Ok(None);
+}

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -69,7 +69,7 @@ pub fn new_generation() -> Result<(), Box<dyn Error>> {
 
     assert!(p.exists(), "No previous generation");
 
-    fs::write(&p, get_generation()?.to_string())?;
+    fs::write(&p, (get_generation()? + 1).to_string())?;
 
     Ok(())
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -71,6 +71,16 @@ impl Game {
             .collect()
     }
 
+    /// Gets the MCTS frames from this game.
+    pub fn get_mcts(&self) -> Vec<Vec<(String, f64)>> {
+        self.mcts.clone()
+    }
+
+    /// Gets the result for this game.
+    pub fn get_result(&self) -> Option<f32> {
+        self.result.clone()
+    }
+
     /// Extends a TrainBatch from a random position in this game.
     pub fn add_to_batch(&self, tb: &mut TrainBatch) {
         let mut rng = thread_rng();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,6 @@ mod tree;
 mod ui;
 mod worker;
 
-use crossterm::{
-    execute,
-    terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    event::{self, Event, KeyCode},
-};
-
 use std::error::Error;
 use std::fs;
 use std::io::{stdout, stdin, Read, Write};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,14 @@ extern crate serde;
 extern crate tch;
 
 mod constants;
+mod dir;
 mod game;
 mod input;
 mod model;
 mod node;
 mod position;
 mod searcher;
+mod train;
 mod tree;
 mod ui;
 mod worker;
@@ -23,8 +25,9 @@ use crossterm::{
 
 use std::error::Error;
 use std::fs;
-use std::io::stdout;
+use std::io::{stdout, stdin, Read, Write};
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread::{sleep, spawn};
 use std::time::Duration;
@@ -49,267 +52,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("\tJustin Stanley <jtst@iastate.edu>");
     println!("================================================================");
 
-    sleep(Duration::from_secs(1));
-
     // Set data dir
-    let data_dir = dirs::data_dir().unwrap().join("kami");
+    let data_dir = dirs::data_dir().expect("Error getting data directory!").join("kami");
 
-    train(&data_dir)?;
+    sleep(Duration::from_secs(1));
+    
+    train::train()?;
 
     println!("Shutdown complete, goodbye :)");
-    Ok(())
-}
-
-/// Runs the training loop.
-/// Starts a TUI and feeds the current status to it.
-fn train(data_dir: &Path) -> Result<(), Box<dyn Error>> {
-    // Set up directories.
-    const MODEL_TYPE: model::Type = model::Type::Torch;
-
-    let games_dir = data_dir.join("games");
-    let model_dir = data_dir.join("model");
-    let archive_dir = data_dir.join("archive");
-
-    // Generate new model if needed.
-    if !model_dir.exists() {
-        println!("Generating new model.");
-        model::generate(&model_dir, MODEL_TYPE)?;
-    }
-
-    // Switch to TUI screen and start rendering TUI.
-    enable_raw_mode().expect("failed setting raw mode");
-
-    execute!(stdout(), EnterAlternateScreen)
-        .expect("failed starting alternate screen");
-
-    let mut ui = Ui::new();
-    ui.start(CrosstermBackend::new(stdout()));
-
-    let ui_tx = ui.tx();
-
-    // Start event thread.
-
-    let should_stop = Arc::new(Mutex::new(false));
-            
-    let inp_ui_tx = ui_tx.clone();
-    let inp_should_stop = should_stop.clone();
-    let inp_thread = spawn(move || {
-        while !*inp_should_stop.lock().unwrap() {
-            match event::read().unwrap() {
-                Event::Key(e) => match e.code {
-                    KeyCode::Char('q') | KeyCode::Esc => {
-                        *inp_should_stop.lock().unwrap() = true;
-                        inp_ui_tx.send(ui::Event::Log("Shutting down..".to_string())).unwrap()
-                    },
-                    KeyCode::Char('p') => inp_ui_tx.send(ui::Event::Pause).unwrap(),
-                    _ => (),
-                },
-                _ => (),
-            };
-        }
-    });
-
-    // Start training loop.
-    loop {
-        let current_model = Arc::new(model::load(&model_dir, true)?);
-
-        // Make games destination.
-        if !games_dir.exists() {
-            fs::create_dir_all(&games_dir)?;
-        }
-
-        // Generate training set.
-        for game_id in 0..constants::TRAINING_SET_SIZE {
-            let game_path = games_dir.join(format!("{}.game", game_id));
-
-            let mut should_generate = false;
-
-            if !game_path.exists() {
-                should_generate = true;
-                ui_tx.send(ui::Event::Log(format!("Starting game {}", game_path.display()))).unwrap();
-            } else {
-                let g = game::Game::load(&game_path)?;
-
-                if !g.is_complete() {
-                    should_generate = true;
-                    ui_tx.send(ui::Event::Log(format!("Resuming incomplete game {}", game_path.display()))).unwrap();
-                }
-            }
-
-            if !should_generate {
-                continue;
-            }
-
-            // Play the game and save to disk.
-            let mut current_game = match Game::load(&game_path) {
-                Ok(g) => g,
-                Err(_) => Game::new(),
-            };
-
-            // Setup a position.
-            let mut current_position = Position::new();
-
-            for mv in current_game.get_actions() {
-                assert!(current_position.make_move(mv));
-            }
-
-            ui_tx.send(ui::Event::Reset).unwrap();
-
-            loop {
-                // Check if the game is over
-                if current_position.is_game_over().is_some() {
-                    break;
-                }
-
-                ui_tx.send(ui::Event::Position(current_position.clone())).unwrap();
-
-                // Initialize searcher
-                let mut search = Searcher::new();
-
-                // Choose temperature for this search
-                let mut temperature = constants::TEMPERATURE;
-
-                if current_position.ply() >= constants::TEMPERATURE_DROPOFF_PLY {
-                    temperature = constants::TEMPERATURE_DROPOFF;
-                }
-
-                let search_rx = search
-                    .start(
-                        Some(constants::SEARCH_TIME),
-                        current_model.clone(),
-                        current_position.clone(),
-                        temperature,
-                        constants::SEARCH_BATCH_SIZE,
-                    )
-                    .unwrap();
-
-                // Display search status until the search is done.
-                loop {
-                    let status = search_rx
-                        .recv()
-                        .expect("unexpected recv fail from search status rx");
-
-                    ui_tx.send(ui::Event::Status(status.clone())).unwrap();
-
-                    if matches!(status, SearchStatus::Done) {
-                        break;
-                    }
-                }
-
-                // Wait for search to stop and collect final tree.
-                let final_tree = search.wait().expect("search did not return tree");
-
-                // Examine tree and perform move selection.
-                let selected_move = final_tree.select();
-
-                // Find move with best n
-                let mut best_n = 0;
-                let mut best_score: Option<f64> = None;
-
-                if let Some(children) = &final_tree[0].children {
-                    for &nd in children {
-                        if final_tree[nd].n > best_n {
-                            best_n = final_tree[nd].n;
-                            best_score = Some(final_tree[nd].q());
-                        }
-                    }
-                }
-
-                if let Some(s) = best_score {
-                    let score_mul = match current_position.side_to_move() {
-                        chess::Color::White => 1.0,
-                        chess::Color::Black => -1.0,
-                    };
-
-                    ui_tx.send(ui::Event::Score(score_mul * s)).unwrap();
-                }
-
-                // Make the selected move.
-                current_position.make_move(selected_move);
-                current_game.make_move(selected_move, final_tree.get_mcts_data());
-
-                // Stop training if the user has requested a stop.
-                if *should_stop.lock().unwrap() {
-                    break;
-                }
-            }
-
-            if current_position.is_game_over().is_some() {
-                // Game is finished, write to disk.
-                current_game.finalize(current_position.is_game_over().unwrap());
-
-                ui_tx.send(ui::Event::Log(format!(
-                    "Game over, result {}",
-                    current_position.is_game_over().unwrap()
-                ))).unwrap();
-            }
-
-            current_game
-                .save(&game_path)
-                .expect("failed saving completed game");
-
-            ui_tx.send(ui::Event::Log(format!("Wrote game to {}", game_path.display()))).unwrap();
-
-            if *should_stop.lock().unwrap() {
-                break;
-            }
-        }
-
-        if *should_stop.lock().unwrap() {
-            break;
-        }
-
-        // Generate training batches.
-        let training_batches: Vec<TrainBatch> = (0..constants::TRAINING_BATCH_COUNT)
-            .map(|_| TrainBatch::generate(&games_dir))
-            .collect::<Result<Vec<TrainBatch>, _>>()?;
-
-        // Train model.
-        ui_tx.send(ui::Event::Log("Training model".to_string())).unwrap();
-        model::train(
-            &model_dir,
-            training_batches,
-            model::get_type(&current_model),
-        )?;
-
-        // Archive games.
-        // Walk through archive generations to find the lowest available slot.
-        let mut cur: usize = 0;
-        let mut gen_path = archive_dir.join(format!("generation_{}", cur));
-
-        if !archive_dir.exists() {
-            fs::create_dir_all(&archive_dir)?;
-        }
-
-        while gen_path.exists() {
-            cur += 1;
-            gen_path = archive_dir.join(format!("generation_{}", cur));
-        }
-
-        // Create target generation dir.
-        fs::create_dir_all(&gen_path)?;
-
-        fs_extra::copy_items(&[&games_dir], gen_path, &fs_extra::dir::CopyOptions::new())?;
-
-        // Regenerate games dir.
-        fs::remove_dir_all(&games_dir)?;
-        fs::create_dir_all(&games_dir)?;
-
-        ui_tx.send(ui::Event::Log(format!("Archived games for generation {}", cur))).unwrap();
-
-        if *should_stop.lock().unwrap() {
-            break;
-        }
-    }
-
-    ui_tx.send(ui::Event::Stop).unwrap();
-
-    inp_thread.join().expect("failed joining input thread");
-    ui.join();
-
-    // Leave TUI screen and reset terminal.
-    execute!(stdout(), LeaveAlternateScreen)
-        .expect("failed leaving alternate screen");
-
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,20 +18,9 @@ mod ui;
 mod worker;
 
 use std::error::Error;
-use std::fs;
-use std::io::{stdout, stdin, Read, Write};
-use std::path::Path;
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-use std::thread::{sleep, spawn};
-use std::time::Duration;
-use tui::backend::CrosstermBackend;
 
-use game::Game;
-use input::trainbatch::TrainBatch;
-use position::Position;
-use searcher::{SearchStatus, Searcher};
-use ui::Ui;
+use std::thread::sleep;
+use std::time::Duration;
 
 /**
  * Server entry point
@@ -47,10 +36,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("================================================================");
 
     // Set data dir
-    let data_dir = dirs::data_dir().expect("Error getting data directory!").join("kami");
+    let _data_dir = dirs::data_dir()
+        .expect("Error getting data directory!")
+        .join("kami");
 
     sleep(Duration::from_secs(1));
-    
+
     train::train()?;
 
     println!("Shutdown complete, goodbye :)");

--- a/src/model.rs
+++ b/src/model.rs
@@ -220,9 +220,11 @@ pub fn execute(m: &Model, b: &Batch) -> Output {
             let frames_tensor = IValue::Tensor(frames_tensor);
             let lmm_tensor = IValue::Tensor(lmm_tensor);
 
-            let nn_result = cmod
-                .forward_is(&[headers_tensor, frames_tensor, lmm_tensor])
-                .expect("network eval failed");
+            let nn_result = tch::no_grad(|| {
+                cmod
+                    .forward_is(&[headers_tensor, frames_tensor, lmm_tensor])
+                    .expect("network eval failed")
+            });
 
             let (policy, value): (Vec<f64>, Vec<f32>) = match nn_result {
                 IValue::Tuple(v) => match &v[..] {

--- a/src/model/torch.rs
+++ b/src/model/torch.rs
@@ -1,0 +1,161 @@
+/// Torch model implementation.
+use crate::input::{batch::Batch, trainbatch::TrainBatch};
+
+use crate::model::*;
+
+use std::error::Error;
+use std::fs::File;
+use std::io::{Write, BufReader, BufRead};
+use std::path::Path;
+
+use tch::{CModule, Device, IValue, Tensor};
+
+pub struct Model {
+    cmod: CModule,
+    cuda: bool,
+}
+
+/// Generates a new model on the disk.
+pub fn generate(p: &Path) -> Result<(), Box<dyn Error>> {
+    File::create(p.join("torch.type"))?;
+
+    let status = std::process::Command::new("python")
+        .args(&[
+            "scripts/init_torch.py",
+            p.join("model.pt").to_str().unwrap(),
+        ])
+        .spawn()?
+        .wait()?
+        .success();
+
+    if !status {
+        return Err("Torch init script returned failure status.".into());
+    }
+
+    println!("Torch init script returned success.");
+    Ok(())
+}
+
+/// Loads a model from a path.
+pub fn load(p: &Path, quiet: bool) -> Result<Model, Box<dyn Error>> {
+    let mut cmod = CModule::load(p.join("model.pt"))?;
+
+    tch::maybe_init_cuda();
+
+    if tch::Cuda::is_available() {
+        if !quiet {
+            println!("CUDA support enabled");
+            println!("{} CUDA devices available", tch::Cuda::device_count());
+
+            if tch::Cuda::cudnn_is_available() {
+                println!("CUDNN acceleration enabled");
+            }
+        }
+
+        cmod.to(Device::Cuda(0), tch::Kind::Float, false);
+    } else {
+        if !quiet {
+            println!("CUDA is not available, using CPU for evaluation");
+        }
+    }
+
+    return Ok(Model {
+        cmod: cmod,
+        cuda: tch::Cuda::is_available(),
+    });
+}
+
+/// Executes a batch on a model.
+pub fn execute(b: &Batch, tmod: &Model) -> Output {
+    let mut headers_tensor = Tensor::of_slice(b.get_headers())
+        .reshape(&[b.get_size() as i64, SQUARE_HEADER_SIZE as i64]);
+
+    let mut frames_tensor = Tensor::of_slice(b.get_frames()).reshape(&[
+        b.get_size() as i64,
+        8,
+        8,
+        (PLY_FRAME_COUNT * PLY_FRAME_SIZE) as i64,
+    ]);
+
+    let mut lmm_tensor =
+        Tensor::of_slice(b.get_lmm()).reshape(&[b.get_size() as i64, 4096]);
+
+    if tmod.cuda {
+        headers_tensor = headers_tensor.to(Device::Cuda(0));
+        frames_tensor = frames_tensor.to(Device::Cuda(0));
+        lmm_tensor = lmm_tensor.to(Device::Cuda(0));
+    }
+
+    let headers_tensor = IValue::Tensor(headers_tensor);
+    let frames_tensor = IValue::Tensor(frames_tensor);
+    let lmm_tensor = IValue::Tensor(lmm_tensor);
+
+    let nn_result = tch::no_grad(|| {
+        tmod
+            .cmod
+            .forward_is(&[headers_tensor, frames_tensor, lmm_tensor])
+            .expect("network eval failed")
+    });
+
+    let (policy, value): (Vec<f64>, Vec<f32>) = match nn_result {
+        IValue::Tuple(v) => match &v[..] {
+            [IValue::Tensor(policy), IValue::Tensor(value)] => {
+                (policy.into(), value.into())
+            }
+            _ => panic!("Unexpected network output tuple size"),
+        },
+        _ => panic!("Unexpected network output type"),
+    };
+
+    assert_eq!(policy.len(), b.get_size() * 4096);
+    assert_eq!(value.len(), b.get_size());
+
+    Output::new(policy, value)
+}
+
+/// Trains a model at a path.
+/// Returns the entire contents of stdout.
+pub fn train<F>(p: &Path, tb: Vec<TrainBatch>, sout: F, loss_path: &Path) -> Result<Vec<String>, Box<dyn Error>> 
+    where F: Fn(&String)
+{
+    let tdata_path = p.join("train_data.json");
+    let mut tdata = File::create(&tdata_path)?;
+
+    tdata.write(serde_json::to_string(&tb)?.as_bytes())?;
+    tdata.flush()?;
+
+    let mut output = std::process::Command::new("python")
+        .stdout(std::process::Stdio::piped())
+        .args(&[
+            "scripts/train_torch.py",
+            p.join("model.pt").to_str().unwrap(),
+            tdata_path
+                .to_str()
+                .expect("failed to get str from tdata pathbuf"),
+            loss_path
+                .to_str()
+                .expect("failed to get str from loss pathbuf"),
+        ])
+        .spawn()?;
+
+    let stdout_reader = BufReader::new(output.stdout.take().unwrap());
+    let mut stdout_lines = Vec::new();
+
+    for line in stdout_reader.lines() {
+        match line {
+            Ok(line) => {
+                sout(&line);
+                stdout_lines.push(line);
+            },
+            Err(_) => break,
+        }
+    }
+
+    let output = output.wait()?;
+
+    if !output.success() {
+        return Err("Torch init script returned failure status.".into());
+    }
+
+    return Ok(stdout_lines);
+}

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,6 +1,5 @@
 use crate::model;
 use chess::{Board, ChessMove, Color, File, MoveGen, Piece, Rank, Square};
-use serde::ser::{Serialize, Serializer};
 
 #[derive(Clone)]
 struct State {
@@ -193,9 +192,7 @@ impl Position {
         let all_pieces = b.color_combined(Color::White) | b.color_combined(Color::Black);
 
         // K(N)(B)vK(N)(B)
-        if b.pieces(Piece::King) | b.pieces(Piece::Knight) | b.pieces(Piece::Bishop) == all_pieces
-            && (b.pieces(Piece::Knight) | b.pieces(Piece::Bishop)).popcnt() < 3
-        {
+        if b.pieces(Piece::King) | b.pieces(Piece::Knight) | b.pieces(Piece::Bishop) == all_pieces && (b.pieces(Piece::Knight) | b.pieces(Piece::Bishop)).popcnt() < 3 {
             return Some(0.0);
         }
 
@@ -332,11 +329,6 @@ impl Position {
         }
     }
 
-    /// Gets the number of moves made in the game.
-    pub fn ply(&self) -> usize {
-        self.states.len() - 1
-    }
-
     /// Returns a pretty-printed board representation.
     pub fn to_string_pretty(&self) -> String {
         (0..8)
@@ -357,15 +349,6 @@ impl Position {
             })
             .collect::<Vec<String>>()
             .join("\n")
-    }
-}
-
-impl Serialize for Position {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.get_fen())
     }
 }
 
@@ -434,19 +417,6 @@ mod test {
         for m in moves {
             assert!(expected_moves.contains(&m));
         }
-    }
-
-    /// Tests the position returns the correct ply count.
-    #[test]
-    fn position_can_get_ply() {
-        let mut p = Position::new();
-        assert_eq!(p.ply(), 0);
-
-        assert!(p.make_move(ChessMove::from_str("e2e4").expect("Failed to parse move.")));
-        assert_eq!(p.ply(), 1);
-
-        assert!(p.make_move(ChessMove::from_str("e7e5").expect("Failed to parse move.")));
-        assert_eq!(p.ply(), 2);
     }
 
     /// Tests the initial position input layer.

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,5 +1,6 @@
 use crate::model;
 use chess::{Board, ChessMove, Color, File, MoveGen, Piece, Rank, Square};
+use serde::ser::{Serialize, Serializer};
 
 #[derive(Clone)]
 struct State {
@@ -354,6 +355,13 @@ impl Position {
             })
             .collect::<Vec<String>>()
             .join("\n")
+    }
+}
+
+impl Serialize for Position {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        serializer.serialize_str(&self.get_fen())
     }
 }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -193,7 +193,9 @@ impl Position {
         let all_pieces = b.color_combined(Color::White) | b.color_combined(Color::Black);
 
         // K(N)(B)vK(N)(B)
-        if b.pieces(Piece::King) | b.pieces(Piece::Knight) | b.pieces(Piece::Bishop) == all_pieces && (b.pieces(Piece::Knight) | b.pieces(Piece::Bishop)).popcnt() < 3 {
+        if b.pieces(Piece::King) | b.pieces(Piece::Knight) | b.pieces(Piece::Bishop) == all_pieces
+            && (b.pieces(Piece::Knight) | b.pieces(Piece::Bishop)).popcnt() < 3
+        {
             return Some(0.0);
         }
 
@@ -360,7 +362,9 @@ impl Position {
 
 impl Serialize for Position {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         serializer.serialize_str(&self.get_fen())
     }
 }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -88,16 +88,6 @@ impl Searcher {
         self
     }
 
-    pub fn temperature(mut self, temperature: f64) -> Self {
-        self.temperature = temperature;
-        self
-    }
-
-    pub fn batch_size(mut self, batch_size: usize) -> Self {
-        self.batch_size = batch_size;
-        self
-    }
-
     pub fn run<F, R>(self, f: F) -> Result<Tree, Box<dyn Error>>
     where
         F: Fn(Status) -> R,
@@ -254,7 +244,6 @@ mod test {
         Searcher::new()
             .maxtime(500)
             .model(mock())
-            .batch_size(4)
             .run(|_| ())
             .expect("search failed");
     }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -63,8 +63,6 @@ impl Searcher {
             position: Position::new(),
             maxnodes: constants::SEARCH_MAXNODES,
             maxtime: constants::SEARCH_TIME,
-            batch_size: constants::SEARCH_BATCH_SIZE,
-            temperature: constants::TEMPERATURE,
         }
     }
 
@@ -96,8 +94,6 @@ impl Searcher {
         let thr_workers = self.workers.clone();
         let thr_rootfen = self.position.get_fen();
         let thr_position = self.position.clone();
-        let thr_temperature = self.temperature.clone();
-        let thr_batch_size = self.batch_size.clone();
         let thr_maxtime = self.maxtime.clone();
         let thr_maxnodes = self.maxnodes.clone();
 
@@ -105,7 +101,7 @@ impl Searcher {
 
         let handle = spawn(move || {
             let (thr_tree_tx, thr_tree_handle) =
-                Tree::new(thr_position, thr_temperature, thr_batch_size).run();
+                Tree::new(thr_position, constants::TEMPERATURE, constants::SEARCH_BATCH_SIZE).run();
 
             for _ in 0..num_cpus::get() {
                 let mut new_worker = Worker::new(thr_tree_tx.clone(), thr_model.clone());

--- a/src/train.rs
+++ b/src/train.rs
@@ -1,0 +1,212 @@
+/// Routines for evaluating model ELO
+
+use crate::constants;
+use crate::dir;
+use crate::input::trainbatch::TrainBatch;
+use crate::game::Game;
+use crate::model::{self, Model};
+use crate::position::Position;
+use crate::ui::{self, Ui};
+use crate::searcher::{Searcher, SearchStatus};
+
+use chess::{ChessMove, Color};
+use crossterm::{
+    execute,
+    terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    event::{self, Event, KeyCode},
+};
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use std::error::Error;
+use std::fs;
+use std::io::{stdout, stdin, Read, Write};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+use tui::backend::CrosstermBackend;
+
+/// Starts the training loop.
+/// Initializes a TUI, starts playing games and evaluating ELO progress.
+pub fn train() -> Result<(), Box<dyn Error>> {
+    // Generate model if needed.
+    let model_dir = dir::model_dir()?;
+    if !model_dir.exists() {
+        model::generate(&model_dir, constants::DEFAULT_MODEL_TYPE)?;
+    }
+
+    // Switch to TUI screen.
+    enable_raw_mode().expect("failed setting raw mode");
+
+    execute!(stdout(), EnterAlternateScreen)
+        .expect("failed starting alternate screen");
+
+    let mut ui = Arc::new(Mutex::new(Ui::new()));
+    ui.lock().unwrap().start(CrosstermBackend::new(stdout()));
+
+    // Start event thread.
+    let should_stop = Arc::new(Mutex::new(false));
+            
+    let inp_ui = ui.clone();
+    let inp_should_stop = should_stop.clone();
+    let inp_thread = spawn(move || {
+        while !*inp_should_stop.lock().unwrap() {
+            match event::read().unwrap() {
+                Event::Key(e) => match e.code {
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        inp_ui.lock().unwrap().request_exit();
+                        inp_ui.lock().unwrap().log("Requested exit.");
+                    },
+                    KeyCode::Char('p') => inp_ui.lock().unwrap().pause(),
+                    _ => (),
+                },
+                _ => (),
+            };
+        }
+    });
+
+    // Start training loop.
+    for generation in dir::current_generation()?..usize::MAX {
+        // Generate training set.
+        if !generate_training_set(ui.clone())? {
+            break;
+        }
+
+        // Archive and train model.
+        ui.lock().unwrap().log("Training model.");
+        advance_model(ui.clone())?;
+
+        // Perform ELO evaluation if ready.
+        if generation % constants::ELO_EVALUATION_INTERVAL == 0 {
+            ui.lock().unwrap().log(format!("Evaluating engine ELO after generation {}.", generation + 1));
+
+            if !evaluate_elo(ui.clone())? {
+                break;
+            }
+        }
+    }
+
+    // Stop input thread.
+    *should_stop.lock().unwrap() = true;
+    inp_thread.join().unwrap();
+
+    // Stop ui thread.
+    ui.lock().unwrap().join();
+
+    // Leave TUI screen and reset terminal.
+    execute!(stdout(), LeaveAlternateScreen)
+        .expect("failed leaving alternate screen");
+
+    return Ok(());
+}
+
+/// Generates a training set. Returns true if the training set is complete, or false if the user requested an exit.
+/// Returns Err() if something fails.
+fn generate_training_set(ui: Arc<Mutex<ui::Ui>>) -> Result<bool, Box<dyn Error>> {
+    ui.lock().unwrap().log("Generating training set.");
+
+    // Load the current model.
+    let model = Arc::new(model::load(&dir::model_dir()?, true)?);
+
+    // Walk through needed games and generate them.
+    while let Some(next_game) = dir::next_game()? {
+        // Set initial position
+        let mut position = Position::new();
+
+        let mut game = if next_game.exists() {
+            ui.lock().unwrap().log(format!("Resuming game {}", next_game.display()));
+            Game::load(&next_game)?
+        } else {
+            ui.lock().unwrap().log(format!("Generating game {}", next_game.display()));
+            Game::new()
+        };
+
+        // Get game back up to current position
+        for mv in &game.get_actions() {
+            assert!(position.make_move(*mv), "Invalid move in resumed game!");
+        }
+
+        // Start searching until game is over.
+        while position.is_game_over().is_none() {
+            if ui.lock().unwrap().should_exit() {
+                break;
+            }
+
+            let (selected_move, mcts) = do_search(model.clone(), ui.clone(), &position)?;
+            assert!(position.make_move(selected_move));
+            game.make_move(selected_move, mcts);
+        }
+
+        // Write game to disk.
+        game.save(&next_game)?;
+
+        // If user wants to quit, stop here.
+        if ui.lock().unwrap().should_exit() {
+            return Ok(false);
+        }
+    }
+
+    ui.lock().unwrap().log(format!("Training set complete, {} games total", constants::TRAINING_SET_SIZE));
+
+    return Ok(true);
+}
+
+fn evaluate_elo(ui: Arc<Mutex<ui::Ui>>) -> Result<bool, Box<dyn Error>> {
+    ui.lock().unwrap().log("Skipping ELO evaluation!");
+    // Start stockfish process.
+    let stockfish_path = "scripts/stockfish_14_x64_avx2";
+
+    let mut stockfish = Command::new(stockfish_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    ui.lock().unwrap().log(format!("Started stockfish: {}", stockfish_path));
+
+    let sf_stdin = stockfish.stdin.take().unwrap();
+    let sf_stdout = stockfish.stdin.take().unwrap();
+
+    return Ok(true);
+}
+
+fn do_search(model: Arc<Model>, ui: Arc<Mutex<ui::Ui>>, position: &Position) -> Result<(ChessMove, Vec<(ChessMove, f64)>), Box<dyn Error>> {
+    // Run search.
+    let search_ui = ui.clone();
+    let tree = Searcher::new()
+        .model(model)
+        .position(position.clone())
+        .run(move |status| {
+            search_ui.lock().unwrap().status(status);
+        })?;
+
+    let score_mul = match position.side_to_move() {
+        Color::White => 1.0,
+        Color::Black => -1.0,
+    };
+
+    ui.lock().unwrap().score(tree.score() * score_mul);
+    return Ok((tree.select(), tree.get_mcts_data()));
+}
+
+/// Advances the model generation.
+/// Expects a complete training batch to be ready.
+fn advance_model(ui: Arc<Mutex<ui::Ui>>) -> Result<(), Box<dyn Error>> {
+    // Archive current generation.
+    ui.lock().unwrap().log("Archiving model.");
+    ui.lock().unwrap().log(format!("Archived as generation {}.", dir::archive()?));
+    
+    // Generate training batches.
+    let training_batches: Vec<TrainBatch> = (0..constants::TRAINING_BATCH_COUNT)
+        .map(|_| TrainBatch::generate(&dir::games_dir()?))
+        .collect::<Result<Vec<TrainBatch>, _>>()?;
+
+    // Train the model in place.
+    ui.lock().unwrap().log("Training model.");
+    let model = model::load(&dir::model_dir()?, true)?;
+    model::train(&dir::model_dir()?, training_batches, model::get_type(&model))?;
+    ui.lock().unwrap().log("Finished training model.");
+
+    return Ok(());
+}

--- a/src/train.rs
+++ b/src/train.rs
@@ -445,7 +445,7 @@ fn do_search(
         .position(position.clone());
 
     if let Some(maxnodes) = maxnodes {
-        tree.maxnodes(maxnodes);
+        tree = tree.maxnodes(maxnodes);
     }
 
     let tree = tree

--- a/src/train.rs
+++ b/src/train.rs
@@ -146,6 +146,18 @@ fn generate_training_set(ui: Arc<Mutex<ui::Ui>>) -> Result<bool, Box<dyn Error>>
         // Finalize game if it is over.
         if let Some(result) = position.is_game_over() {
             game.finalize(result);
+
+            ui.lock().unwrap().log(format!("Game over, {}",
+                if result > 0.0 {
+                    "1-0"
+                } else {
+                    if result < 0.0 {
+                        "0-1"
+                    } else {
+                        "1/2-1/2"
+                    }
+                }
+            ));
         }
 
         // Write game to disk.

--- a/src/train.rs
+++ b/src/train.rs
@@ -197,6 +197,8 @@ fn evaluate_elo(ui: Arc<Mutex<ui::Ui>>) -> Result<bool, Box<dyn Error>> {
     return Ok(true);
 }
 
+/// Searches a position.
+/// Returns the selected move along with the search MCTS counts.
 fn do_search(model: Arc<Model>, ui: Arc<Mutex<ui::Ui>>, position: &Position) -> Result<(ChessMove, Vec<(ChessMove, f64)>), Box<dyn Error>> {
     // Run search.
     let search_ui = ui.clone();

--- a/src/train.rs
+++ b/src/train.rs
@@ -21,7 +21,7 @@ use std::process::{Command, Stdio};
 
 use std::error::Error;
 use std::fs;
-use std::io::{stdout, BufRead, BufReader, Read, Write};
+use std::io::{stdout, BufRead, BufReader, Write};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;

--- a/src/train.rs
+++ b/src/train.rs
@@ -470,6 +470,8 @@ fn advance_model(ui: Arc<Mutex<ui::Ui>>) -> Result<(), Box<dyn Error>> {
         &dir::model_dir()?,
         training_batches,
         model::get_type(&model),
+        |sout| ui.lock().unwrap().log(sout),
+        &dir::get_generation_archive()?.join("loss")
     )?;
     ui.lock().unwrap().log("Finished training model.");
 

--- a/src/train.rs
+++ b/src/train.rs
@@ -128,11 +128,15 @@ fn generate_training_set(ui: Arc<Mutex<ui::Ui>>) -> Result<bool, Box<dyn Error>>
             assert!(position.make_move(*mv), "Invalid move in resumed game!");
         }
 
+        ui.lock().unwrap().reset();
+
         // Start searching until game is over.
         while position.is_game_over().is_none() {
             if ui.lock().unwrap().should_exit() {
                 break;
             }
+
+            ui.lock().unwrap().position(position.clone());
 
             let (selected_move, mcts) = do_search(model.clone(), ui.clone(), &position)?;
             assert!(position.make_move(selected_move));

--- a/src/train.rs
+++ b/src/train.rs
@@ -441,20 +441,11 @@ fn do_search(
 ) -> Result<(ChessMove, Vec<(ChessMove, f64)>), Box<dyn Error>> {
     // Run search.
     let search_ui = ui.clone();
-    let mut tree = Searcher::new()
+    let tree = Searcher::new()
         .model(model)
-        .position(position.clone());
-
-    // Apply node/time limits
-    if let Some(maxnodes) = maxnodes {
-        tree = tree.maxnodes(maxnodes);
-    }
-
-    if let Some(maxtime) = maxtime {
-        tree = tree.maxtime(maxtime);
-    }
-
-    let tree = tree
+        .position(position.clone())
+        .maxnodes(maxnodes)
+        .maxtime(maxtime)
         .run(move |status| {
             search_ui.lock().unwrap().status(status);
         })?;

--- a/src/train.rs
+++ b/src/train.rs
@@ -466,7 +466,7 @@ fn advance_model(ui: Arc<Mutex<ui::Ui>>) -> Result<(), Box<dyn Error>> {
     // Train the model in place.
     ui.lock().unwrap().log("Training model.");
     let model = model::load(&dir::model_dir()?, true)?;
-    model::train(
+    let train_output = model::train(
         &dir::model_dir()?,
         training_batches,
         model::get_type(&model),
@@ -474,6 +474,9 @@ fn advance_model(ui: Arc<Mutex<ui::Ui>>) -> Result<(), Box<dyn Error>> {
         &dir::get_generation_archive()?.join("loss")
     )?;
     ui.lock().unwrap().log("Finished training model.");
+
+    // Write training log to archive.
+    fs::write(dir::get_generation_archive()?.join("train.stdout"), train_output.join("\n").as_bytes())?;
 
     // Advance generation number.
     dir::new_generation()?;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -256,7 +256,7 @@ impl Tree {
             .map(|(&cidx, noise)| {
                 let child = &mut self[cidx];
                 let uct = child.q()
-                    + (((child.p / cur_ptotal) * (1 - constants::PUCT_NOISE_WEIGHT)) + constants::PUCT_NOISE_WEIGHT * noise) * constants::PUCT_POLICY_WEIGHT * (cur_n as f64).sqrt()
+                    + (((child.p / cur_ptotal) * (1.0 - constants::PUCT_NOISE_WEIGHT)) + constants::PUCT_NOISE_WEIGHT * noise) * constants::PUCT_POLICY_WEIGHT * (cur_n as f64).sqrt()
                         / (child.n as f64 + 1.0);
 
                 assert!(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -368,6 +368,24 @@ impl Tree {
         return actions[index.sample(&mut rng)];
     }
 
+    /// Gets the predicted current score.
+    pub fn score(&self) -> f64 {
+        // Find move with best n
+        let mut best_n = 0;
+        let mut best_score: Option<f64> = None;
+
+        if let Some(children) = &self[0].children {
+            for &nd in children {
+                if self[nd].n > best_n {
+                    best_n = self[nd].n;
+                    best_score = Some(self[nd].q());
+                }
+            }
+        }
+
+        return best_score.unwrap_or(0.0);
+    }
+
     /// Gets MCTS visit counts for the root children in pair format.
     /// Output is normalized with temperature + softmax function.
     pub fn get_mcts_data(&self) -> Vec<(ChessMove, f64)> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -244,7 +244,10 @@ impl Tree {
         let p_noise = match children.len() {
             1 => vec![1.0],
             len => {
-                let dist = rand::distributions::Dirichlet::new_with_param(constants::PUCT_NOISE_ALPHA, len);
+                let dist = rand::distributions::Dirichlet::new_with_param(
+                    constants::PUCT_NOISE_ALPHA,
+                    len,
+                );
                 let mut rng = rand::thread_rng();
                 dist.sample(&mut rng)
             }
@@ -256,7 +259,10 @@ impl Tree {
             .map(|(&cidx, noise)| {
                 let child = &mut self[cidx];
                 let uct = child.q()
-                    + (((child.p / cur_ptotal) * (1.0 - constants::PUCT_NOISE_WEIGHT)) + constants::PUCT_NOISE_WEIGHT * noise) * constants::PUCT_POLICY_WEIGHT * (cur_n as f64).sqrt()
+                    + (((child.p / cur_ptotal) * (1.0 - constants::PUCT_NOISE_WEIGHT))
+                        + constants::PUCT_NOISE_WEIGHT * noise)
+                        * constants::PUCT_POLICY_WEIGHT
+                        * (cur_n as f64).sqrt()
                         / (child.n as f64 + 1.0);
 
                 assert!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -596,4 +596,82 @@ mod test {
 
         t.join();
     }
+
+    #[test]
+    /// Tests the TUI exit request works.
+    pub fn ui_can_request_exit() {
+        let mut t = Ui::new();
+
+        t.start(TestBackend::new(800, 600));
+        t.request_exit();
+
+        sleep(Duration::from_secs(1));
+
+        assert!(t.should_exit());
+        t.join();
+    }
+
+    #[test]
+    /// Tests the TUI log request does not crash.
+    pub fn ui_can_log() {
+        let mut t = Ui::new();
+
+        t.start(TestBackend::new(800, 600));
+        t.log("Test log!");
+
+        t.join();
+    }
+
+    #[test]
+    /// Tests the TUI position tx does not crash.
+    pub fn ui_can_send_position() {
+        let mut t = Ui::new();
+
+        t.start(TestBackend::new(800, 600));
+        t.position(Position::new());
+
+        t.join();
+    }
+
+    #[test]
+    /// Tests the TUI pause/unpause does not crash.
+    pub fn ui_can_pause_unpause() {
+        let mut t = Ui::new();
+        t.start(TestBackend::new(800, 600));
+
+        t.pause();
+        t.pause();
+
+        t.join();
+    }
+
+    #[test]
+    /// Tests the TUI rest does not crash.
+    pub fn ui_can_reset() {
+        let mut t = Ui::new();
+        t.start(TestBackend::new(800, 600));
+
+        t.reset();
+
+        t.join();
+    }
+
+    #[test]
+    /// Tests the TUI status send does not crash.
+    pub fn ui_can_send_status() {
+        let mut t = Ui::new();
+
+        t.start(TestBackend::new(800, 600));
+        t.log("Test log!");
+
+        searcher::Searcher::new()
+            .maxnodes(Some(1000))
+            .maxtime(Some(1000))
+            .run(|stat| {
+                t.status(stat);
+            })
+            .expect("search failed");
+
+        t.join();
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -578,6 +578,8 @@ mod test {
     use super::*;
     use std::thread::sleep;
     use tui::backend::TestBackend;
+    use crate::model::Model;
+    use std::sync::Arc;
 
     /// Tests the TUI can be initialized.
     #[test]
@@ -650,9 +652,7 @@ mod test {
     pub fn ui_can_reset() {
         let mut t = Ui::new();
         t.start(TestBackend::new(800, 600));
-
         t.reset();
-
         t.join();
     }
 
@@ -665,6 +665,7 @@ mod test {
         t.log("Test log!");
 
         searcher::Searcher::new()
+            .model(Arc::new(Model::Mock))
             .maxnodes(Some(1000))
             .maxtime(Some(1000))
             .run(|stat| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -60,8 +60,16 @@ impl Ui {
         self.tx.as_ref().unwrap().send(Event::Status(status)).expect("ui tx failed");
     }
 
+    pub fn position(&self, position: Position) {
+        self.tx.as_ref().unwrap().send(Event::Position(position)).expect("ui tx failed");
+    }
+
     pub fn pause(&self) {
         self.tx.as_ref().unwrap().send(Event::Pause).expect("ui tx failed");
+    }
+
+    pub fn reset(&self) {
+        self.tx.as_ref().unwrap().send(Event::Reset).expect("ui tx failed");
     }
 
     pub fn request_exit(&mut self) {
@@ -497,11 +505,6 @@ impl Ui {
         }));
     }
 
-    /// Gets an event sender handle for this TUI.
-    pub fn tx(&self) -> Sender<Event> {
-        self.tx.as_ref().expect("TUI not running").clone()
-    }
-
     /// Joins the TUI thread.
     pub fn join(&mut self) {
         self.tx.as_ref().unwrap().send(Event::Stop).expect("ui tx failed");
@@ -530,7 +533,6 @@ mod test {
 
         sleep(Duration::from_secs(1));
 
-        t.tx().send(Event::Stop).unwrap();
         t.join();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,13 +2,7 @@ use crate::constants;
 use crate::position::Position;
 use crate::searcher;
 
-use std::sync::{
-    mpsc::{
-        channel,
-        Sender,
-        RecvTimeoutError::Timeout,
-    },
-};
+use std::sync::mpsc::{channel, RecvTimeoutError::Timeout, Sender};
 
 use std::thread::{spawn, JoinHandle};
 use std::time::{Duration, Instant};
@@ -18,7 +12,9 @@ use tui::{
     style::{Color, Modifier, Style},
     symbols,
     text::Span,
-    widgets::{Axis, Block, Borders, Cell, Chart, Dataset, Gauge, Paragraph, Row, Table, Wrap, GraphType},
+    widgets::{
+        Axis, Block, Borders, Cell, Chart, Dataset, Gauge, GraphType, Paragraph, Row, Table, Wrap,
+    },
     Terminal,
 };
 
@@ -49,27 +45,51 @@ impl Ui {
     }
 
     pub fn log(&self, msg: impl ToString) {
-        self.tx.as_ref().unwrap().send(Event::Log(msg.to_string())).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Log(msg.to_string()))
+            .expect("ui tx failed");
     }
 
     pub fn score(&self, score: f64) {
-        self.tx.as_ref().unwrap().send(Event::Score(score)).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Score(score))
+            .expect("ui tx failed");
     }
 
     pub fn status(&self, status: searcher::Status) {
-        self.tx.as_ref().unwrap().send(Event::Status(status)).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Status(status))
+            .expect("ui tx failed");
     }
 
     pub fn position(&self, position: Position) {
-        self.tx.as_ref().unwrap().send(Event::Position(position)).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Position(position))
+            .expect("ui tx failed");
     }
 
     pub fn pause(&self) {
-        self.tx.as_ref().unwrap().send(Event::Pause).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Pause)
+            .expect("ui tx failed");
     }
 
     pub fn reset(&self) {
-        self.tx.as_ref().unwrap().send(Event::Reset).expect("ui tx failed");
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Reset)
+            .expect("ui tx failed");
     }
 
     pub fn request_exit(&mut self) {
@@ -82,7 +102,8 @@ impl Ui {
 
     /// Renders the NPS history graph.
     fn render_nps<T>(f: &mut tui::Frame<T>, rect: tui::layout::Rect, data: &Vec<f64>)
-    where T: tui::backend::Backend
+    where
+        T: tui::backend::Backend,
     {
         const NPS_BACKTIME: u64 = 15000;
         const MAX_FRAMES: u64 = NPS_BACKTIME / constants::SEARCH_STATUS_RATE;
@@ -124,30 +145,27 @@ impl Ui {
                     .style(Style::default().fg(Color::Gray))
                     .bounds([0.0, data.len() as f64])
                     .labels(
-                        [format!("T-{}ms", data.len() as u64 * constants::SEARCH_STATUS_RATE), "T-0ms".to_string()]
-                            .iter()
-                            .cloned()
-                            .map(Span::from)
-                            .collect(),
+                        [
+                            format!("T-{}ms", data.len() as u64 * constants::SEARCH_STATUS_RATE),
+                            "T-0ms".to_string(),
+                        ]
+                        .iter()
+                        .cloned()
+                        .map(Span::from)
+                        .collect(),
                     ),
             )
             .y_axis(
                 Axis::default()
                     .title("nodes/s")
                     .style(Style::default().fg(Color::Gray))
-                    .bounds([
-                        0.0,
-                        nps_max * 1.25,
-                    ])
+                    .bounds([0.0, nps_max * 1.25])
                     .labels(
-                        [
-                            0.0,
-                            nps_max * 1.25,
-                        ]
-                        .iter()
-                        .cloned()
-                        .map(|x| Span::from(format!("{}", x as usize)))
-                        .collect(),
+                        [0.0, nps_max * 1.25]
+                            .iter()
+                            .cloned()
+                            .map(|x| Span::from(format!("{}", x as usize)))
+                            .collect(),
                     ),
             );
 
@@ -156,7 +174,8 @@ impl Ui {
 
     /// Renders the value graph.
     fn render_score<T>(f: &mut tui::Frame<T>, rect: tui::layout::Rect, data: &Vec<f64>)
-    where T: tui::backend::Backend
+    where
+        T: tui::backend::Backend,
     {
         let mut data: Vec<(f64, f64)> = data
             .iter()
@@ -177,9 +196,7 @@ impl Ui {
             .data(&data);
 
         let baseline_data: Vec<(f64, f64)> = (0..rect.width)
-            .map(|x| {
-                (x as f64 / rect.width as f64 * data.len() as f64, 0.0)
-            })
+            .map(|x| (x as f64 / rect.width as f64 * data.len() as f64, 0.0))
             .collect();
 
         let baseline_dataset = Dataset::default()
@@ -230,7 +247,8 @@ impl Ui {
 
     /// Starts the TUI thread and begins displaying status data.
     pub fn start<T>(&mut self, backend: T)
-    where T: tui::backend::Backend + Send + 'static
+    where
+        T: tui::backend::Backend + Send + 'static,
     {
         let (tx, rx) = channel();
         self.tx = Some(tx);
@@ -322,7 +340,7 @@ impl Ui {
                                     format!("{:.2}%", nd.p_pct * 100.0),
                                     format!("{:+.2}", nd.q),
                                     format!("{}", nd.depth),
-                                    format!("{}%", if nd.n <= 0 { 0 } else { nd.tn * 100 / nd.n })
+                                    format!("{}%", if nd.n <= 0 { 0 } else { nd.tn * 100 / nd.n }),
                                 ])
                             });
 
@@ -409,14 +427,15 @@ impl Ui {
                             let perf_header =
                                 Row::new(perf_header_cells).height(1).bottom_margin(1);
 
-                            let perf_rows = cstatus.workers.iter().cloned().enumerate().map(|(id, w)| {
-                                Row::new([
-                                    id.to_string(),
-                                    w.state.clone(),
-                                    w.total_nodes.to_string(),
-                                    w.batch_sizes.len().to_string(),
-                                ])
-                            });
+                            let perf_rows =
+                                cstatus.workers.iter().cloned().enumerate().map(|(id, w)| {
+                                    Row::new([
+                                        id.to_string(),
+                                        w.state.clone(),
+                                        w.total_nodes.to_string(),
+                                        w.batch_sizes.len().to_string(),
+                                    ])
+                                });
 
                             let t = Table::new(perf_rows)
                                 .header(perf_header)
@@ -474,8 +493,12 @@ impl Ui {
                 let mut stop = false;
 
                 // Process TUI events
-                while frame_timer.elapsed().as_millis() < (1000 / constants::TUI_FRAME_RATE) as u128 {
-                    match rx.recv_timeout(Duration::from_millis((1000 / constants::TUI_FRAME_RATE) - frame_timer.elapsed().as_millis() as u64)) {
+                while frame_timer.elapsed().as_millis() < (1000 / constants::TUI_FRAME_RATE) as u128
+                {
+                    match rx.recv_timeout(Duration::from_millis(
+                        (1000 / constants::TUI_FRAME_RATE)
+                            - frame_timer.elapsed().as_millis() as u64,
+                    )) {
                         Ok(evt) => match evt {
                             Event::Stop => stop = true,
                             Event::Log(s) => log_buf.push(s),
@@ -489,9 +512,9 @@ impl Ui {
                                 } else {
                                     log_buf.push("Paused display.".to_string());
                                 }
-                                
+
                                 paused = !paused;
-                            },
+                            }
                         },
                         Err(Timeout) => (),
                         Err(e) => Err(e).expect("unexpected recv fail"),
@@ -507,8 +530,16 @@ impl Ui {
 
     /// Joins the TUI thread.
     pub fn join(&mut self) {
-        self.tx.as_ref().unwrap().send(Event::Stop).expect("ui tx failed");
-        self.handle.take().expect("TUI not running").join().expect("TUI thread failed to join")
+        self.tx
+            .as_ref()
+            .unwrap()
+            .send(Event::Stop)
+            .expect("ui tx failed");
+        self.handle
+            .take()
+            .expect("TUI not running")
+            .join()
+            .expect("TUI thread failed to join")
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -452,14 +452,17 @@ impl Ui {
                             // Render search progress
                             let mut prog_rect = board_rect.clone();
 
-                            prog_rect.y += prog_rect.height - 2;
+                            prog_rect.y += prog_rect.height;
                             prog_rect.height = 2;
 
-                            let label =
-                                format!("{}/{}", cstatus.total_nodes, constants::SEARCH_MAXNODES);
+                            if let Some(maxnodes) = cstatus.maxnodes {
+                                prog_rect.y -= 2;
 
-                            let prog_widget = Gauge::default()
-                                .block(Block::default().title("Progress"))
+                                let label =
+                                    format!("{}/{}", cstatus.total_nodes, maxnodes);
+
+                                let maxtime_widget = Gauge::default()
+                                .block(Block::default().title("NODE progress"))
                                 .gauge_style(
                                     Style::default()
                                         .fg(Color::Green)
@@ -468,14 +471,41 @@ impl Ui {
                                 )
                                 .percent(
                                     ((cstatus.total_nodes as f32 * 100.0
-                                        / constants::SEARCH_MAXNODES as f32)
+                                        / maxnodes as f32)
                                         as u16)
                                         .min(100),
                                 )
                                 .label(label)
                                 .use_unicode(true);
 
-                            f.render_widget(prog_widget, prog_rect);
+                                f.render_widget(maxtime_widget, prog_rect);
+                            }
+                            
+                            if let Some(maxtime) = cstatus.maxnodes {
+                                prog_rect.y -= 2;
+
+                                let label =
+                                    format!("{:.1}/{:.1}", cstatus.elapsed_ms as f32 / 1000.0, maxtime as f32 / 1000.0);
+
+                                let maxtime_widget = Gauge::default()
+                                .block(Block::default().title("NODE progress"))
+                                .gauge_style(
+                                    Style::default()
+                                        .fg(Color::Blue)
+                                        .bg(Color::Black)
+                                        .add_modifier(Modifier::BOLD),
+                                )
+                                .percent(
+                                    ((cstatus.elapsed_ms as f32
+                                        / maxtime as f32)
+                                        as u16)
+                                        .min(100),
+                                )
+                                .label(label)
+                                .use_unicode(true);
+
+                                f.render_widget(maxtime_widget, prog_rect);
+                            }
 
                             // Render search score
                             Ui::render_score(f, score_rect, &score_buf);


### PR DESCRIPTION
This PR adds scripts for tracking the progression of the model strength. It adds skeleton code for tracking several other long-term changes in model performance as well. It would be good to add tracking for average loss by generation as well as delta loss for each training run. 

ELO ratings are currently a tournament-like performance estimate and need to be changed to a true ELO calculation as the model should clearly not be rated 700 as a worst possible performance.

This PR also refactors the archiving system into `dir.rs`, removing the need for moving files and folders after every training session and eliminating the dependency on `fs_extra`. This will definitely require additional testing before merging.

Incidentally this PR also contains modifications to the PUCT calucation as well as changing the model optimizer to RMSprop for dynamic learning rates with an added L2 regularization.

Closes #3 
Closes #4 
Closes #12

Remaining tasks before merging:
- [x] Accurate ELO calculation
- [x] Tests for archive flow
- [x] Tests for training flow (excl. TUI, or just exclude train.rs entirely)
- [x] Train stdout in TUI log, archive as well
- [x] Shorter performance evaluation
- [x] Potentially shorter nodecount, faster games